### PR TITLE
Allow user to define `clientId` in runtimeConfig directly

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,6 +10,7 @@
       "license": "MIT",
       "dependencies": {
         "@nuxt/kit": "^3.10.0",
+        "defu": "^6.1.4",
         "unimport": "^3.7.1",
         "vue3-google-signin": "latest"
       },
@@ -4986,7 +4987,8 @@
     "node_modules/defu": {
       "version": "6.1.4",
       "resolved": "https://registry.npmjs.org/defu/-/defu-6.1.4.tgz",
-      "integrity": "sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg=="
+      "integrity": "sha512-mEQCMmwJu317oSz8CwdIOdwf3xMif1ttiM8LTufzc3g6kR+9Pe236twL8j3IYT1F7GfRgGcW6MWxzZjLIkuHIg==",
+      "license": "MIT"
     },
     "node_modules/delegates": {
       "version": "1.0.0",

--- a/package.json
+++ b/package.json
@@ -68,6 +68,7 @@
   ],
   "dependencies": {
     "@nuxt/kit": "^3.10.0",
+    "defu": "^6.1.4",
     "unimport": "^3.7.1",
     "vue3-google-signin": "latest"
   },

--- a/src/module.ts
+++ b/src/module.ts
@@ -1,13 +1,14 @@
-import { resolve } from 'path'
-import { fileURLToPath } from 'url'
 import {
-  defineNuxtModule,
-  addPlugin,
   addComponent,
-  useLogger,
-  addImportsSources
+  addImportsSources,
+  addPlugin,
+  defineNuxtModule,
+  useLogger
 } from '@nuxt/kit'
+import { defu } from 'defu'
+import { resolve } from 'path'
 import { defineUnimportPreset } from 'unimport'
+import { fileURLToPath } from 'url'
 
 const MODULE_NAME = 'nuxt-vue3-google-signin'
 
@@ -34,14 +35,15 @@ export default defineNuxtModule<ModuleOptions>({
     clientId: ''
   },
   setup (options, nuxt) {
-    if (isEmpty(options.clientId)) {
+    nuxt.options.runtimeConfig.public.googleSignIn = defu(
+      nuxt.options.runtimeConfig.public.googleSignIn,
+      { clientId: options.clientId }
+    )
+
+    if (isEmpty(nuxt.options.runtimeConfig.public.googleSignIn.clientId)) {
       useLogger(MODULE_NAME).error(
         'provide googleSignIn.clientId in appConfig'
       )
-    }
-
-    nuxt.options.runtimeConfig.public.googleSignIn = {
-      clientId: options.clientId
     }
 
     const runtimeDir = fileURLToPath(new URL('./runtime', import.meta.url))

--- a/src/module.ts
+++ b/src/module.ts
@@ -1,3 +1,5 @@
+import { resolve } from 'path'
+import { fileURLToPath } from 'url'
 import {
   addComponent,
   addImportsSources,
@@ -6,9 +8,7 @@ import {
   useLogger
 } from '@nuxt/kit'
 import { defu } from 'defu'
-import { resolve } from 'path'
 import { defineUnimportPreset } from 'unimport'
-import { fileURLToPath } from 'url'
 
 const MODULE_NAME = 'nuxt-vue3-google-signin'
 


### PR DESCRIPTION
I wanted to use [environment variables in runtime config & overwrite](https://nuxt.com/docs/guide/going-further/runtime-config#environment-variables).

Following the [documentation](https://nuxt.com/docs/guide/going-further/modules) i used [defu](https://npmjs.com/package/defu) and now we're allowed to define the `clientId` in `runtimeConfig` without having a blocking error.